### PR TITLE
Fixes to work with kicad 7

### DIFF
--- a/kimotor_fillet.py
+++ b/kimotor_fillet.py
@@ -19,7 +19,7 @@ def fillet(board, group, t1, t2, r, side=1):
         t1 (_type_): first track
         t2 (_type_): second track
         r (_type_): fillet radius
-        side (_type_): side of the arc to offeset (1:R, -1:L) 
+        side (_type_): side of the arc to offeset (1:R, -1:L)
     """
 
     t1_arc = t1.GetClass() == 'PCB_ARC'
@@ -70,20 +70,20 @@ def fillet(board, group, t1, t2, r, side=1):
         l = np.array([c, [t1e.x, t1e.y, 0]])
         lv = kla.line_vec(l)
         m = c + np.dot(r, lv)
-        
-    
-    # generate fillet track 
+
+
+    # generate fillet track
     t = pcbnew.PCB_ARC(board)
     t.SetLayer( t1.GetLayer() )
     t.SetWidth( t1.GetWidth() )
-    t.SetStart( pcbnew.wxPoint(int(p1[0]),int(p1[1])) )
-    t.SetMid( pcbnew.wxPoint(int(m[0]),int(m[1])) )
-    t.SetEnd( pcbnew.wxPoint(int(p2[0]),int(p2[1])) )
+    t.SetStart( pcbnew.VECTOR2I(int(p1[0]),int(p1[1])) )
+    t.SetMid( pcbnew.VECTOR2I(int(m[0]),int(m[1])) )
+    t.SetEnd( pcbnew.VECTOR2I(int(p2[0]),int(p2[1])) )
     board.Add(t)
     group.AddItem(t)
     # trim tracks
-    t1.SetEnd( pcbnew.wxPoint(p1[0],p1[1])  )
-    t2.SetStart( pcbnew.wxPoint(p2[0],p2[1])  )
+    t1.SetEnd( pcbnew.VECTOR2I(int(p1[0]),int(p1[1]))  )
+    t2.SetStart( pcbnew.VECTOR2I(int(p2[0]),int(p2[1]))  )
 
 ## borrowed from fillet_helper.py
 ## https://github.com/tywtyw2002/FilletEdge/blob/master/fillet_helper.py
@@ -98,10 +98,10 @@ def fillet_outline(board, a, b, fillet_value):
         b_reverse = 1
         a_set = a.SetStart
         b_set = b.SetStart
-        co_point = pcbnew.wxPoint(a_s.x, a_s.y)
+        co_point = pcbnew.VECTOR2I(a_s.x, a_s.y)
 
         if a_e == b_s or a_e == b_e:
-            co_point = pcbnew.wxPoint(a_e.x, a_e.y)
+            co_point = pcbnew.VECTOR2I(a_e.x, a_e.y)
             a_set = a.SetEnd
             a_reverse = -1
         elif a_s != b_s and a_s != b_e:
@@ -134,11 +134,11 @@ def fillet_outline(board, a, b, fillet_value):
         if int(deg) != 90 and int(deg) != -90:
             offset = abs(offset * math.tan((math.pi - theta) / 2))
 
-        a_point = pcbnew.wxPoint(
+        a_point = pcbnew.VECTOR2I(
             int(co_point.x + offset * math.cos(a_v.Angle())),
             int(co_point.y - offset * math.sin(a_v.Angle()))
         )
-        b_point = pcbnew.wxPoint(
+        b_point = pcbnew.VECTOR2I(
             int(co_point.x + offset * math.cos(b_v.Angle())),
             int(co_point.y - offset * math.sin(b_v.Angle()))
         )
@@ -159,16 +159,16 @@ def fillet_outline(board, a, b, fillet_value):
 
         c_v = a_v.Resize(1000000) + b_v.Resize(1000000)
         c_angle = c_v.Angle()
-        
+
         if offset == fillet_value:
             # 90 or -90
-            s_arc.SetCenter(pcbnew.wxPoint(
+            s_arc.SetCenter(pcbnew.VECTOR2I(
                 a_point.x + b_point.x - co_point.x,
                 a_point.y + b_point.y - co_point.y
             ))
         else:
             coffset = abs(fillet_value / math.cos((math.pi - theta) / 2))
-            s_arc.SetCenter(pcbnew.wxPoint(
+            s_arc.SetCenter(pcbnew.VECTOR2I(
                 co_point.x + int(coffset * math.cos(c_angle)),
                 co_point.y - int(coffset * math.sin(c_angle))
             ))

--- a/kimotor_linalg.py
+++ b/kimotor_linalg.py
@@ -17,12 +17,12 @@ def line_vec(l):
     # line unit vector
     p1 = l[0]   # start point [x,y]
     p2 = l[1]   # end point [x, y]
-    
+
     dx = p2[0]-p1[0]
     dy = p2[1]-p1[1]
     d = math.sqrt(dx**2 + dy**2)
     v = np.array([ dx/d, dy/d, 0])
-    
+
     return v
 def line(l):
     # find params of line equation ( y = mx + k ), given a track
@@ -32,7 +32,7 @@ def line(l):
 
     dx = p2[0]-p1[0]
     dy = p2[1]-p1[1]
-    
+
     m = dy/dx
 
     k = p1[1] - m * p1[0]
@@ -49,8 +49,8 @@ def circle_to_polygon(r,n=100):
 
     for i in range(n):
         x = int( r * math.cos(i*dth) )
-        y = int( r * math.sin(i*dth) )         
-        p.append( pcbnew.wxPoint( x,y ) )
+        y = int( r * math.sin(i*dth) )
+        p.append( pcbnew.VECTOR2I( x,y ) )
 
     return p
 
@@ -63,14 +63,14 @@ def line_points(t):
 
 def line_offset(l, r):
     # offset a line l by distance r (+ shifts L, - shifts R)
-    
+
     p1 = l[0]
     p2 = l[1]
 
     vl = np.array([ p2[0]-p1[0], p2[1]-p1[1], 0 ])
     vlu = vl/np.linalg.norm(vl)
     z = np.array([0,0,1])
-    
+
     # ortho
     vln = np.cross( z, vlu )
 
@@ -89,8 +89,8 @@ def circle_line_tg(l, c,r):
     vc = np.array([ c[0]-p1[0], c[1]-p1[1], 0 ] )
 
     # unit vectors
-    vlu = vl/np.linalg.norm(vl) 
-    vcu = vc/np.linalg.norm(vc) 
+    vlu = vl/np.linalg.norm(vl)
+    vcu = vc/np.linalg.norm(vc)
     z = np.array([0,0,1])
 
     # side, cw or ccw
@@ -125,7 +125,7 @@ def circle_line_sec(l, c,r):
     return np.array([x,y])
 
 def circle_circle_tg(p1,r1,p2,r2):
-    
+
     if r1<r2:
         dx = p1[0]-p2[0]
         dy = p1[1]-p2[1]
@@ -147,13 +147,13 @@ def track_arc_trim(t, ne):
     s = t.GetStart()
     c = t.GetCenter()
     r = t.GetRadius()
-    
+
     m = circle_arc_mid( [s.x, s.y], [ne.x, ne.y], [c.x, c.y, 0], r )
-    
-    return pcbnew.wxPoint(m[0],m[1])
+
+    return pcbnew.VECTOR2I(int(m[0]),int(m[1]))
 
 def circle_arc_mid(p1,p2, c,r):
-    
+
     # mid point of segment connecting arc end points
     m = [ (p1[0]+p2[0])/2, (p1[1]+p2[1])/2 ]
 
@@ -189,7 +189,7 @@ def line_line_intersect(l1,l2):
     x34 = p3[0] - p4[0]
     y12 = p1[1] - p2[1]
     y34 = p3[1] - p4[1]
-    
+
     nx = np.linalg.det(np.array( [[a12, x12], [a34, x34]] ))
     ny = np.linalg.det(np.array( [[a12, y12], [a34, y34]] ))
     d = np.linalg.det(np.array( [[x12, y12], [x34, y34]] ))
@@ -201,7 +201,7 @@ def circle_line_intersect(l, c,r, ref=1):
 
     Args:
         l (_type_): 2D array of the line start and end points
-        c (_type_): coordinates [x,y] of the circle center 
+        c (_type_): coordinates [x,y] of the circle center
         r (_type_): radius of the circle
         ref (int, optional): line point to use as reference (0=start, 1=end). Defaults to 1.
 
@@ -211,7 +211,7 @@ def circle_line_intersect(l, c,r, ref=1):
 
     # TODO: this fails for dx=0 (m=inf)
     m,k = line(l)
-    
+
     xc = c[0]
     yc = c[1]
 
@@ -223,14 +223,14 @@ def circle_line_intersect(l, c,r, ref=1):
     #wx.LogError(f'dsc {dsc}')
     #dsc = np.abs(dsc)
 
-    # pick the intersect point closest to the selected reference 
+    # pick the intersect point closest to the selected reference
     # point (start or end) of the line
     pref = np.array(l[ref])
     x1 = (-b - math.sqrt(dsc)) / (2*a)
     p1 = np.array([x1, m*x1 + k, 0])
     x2 = (-b + math.sqrt(dsc)) / (2*a)
     p2 = np.array([x2, m*x2 + k, 0])
-    
+
     d1 = np.linalg.norm(p1-pref)
     d2 = np.linalg.norm(p2-pref)
 
@@ -253,14 +253,14 @@ def circle_circle_intersect(c1,r1,c2,r2):
     # https://math.stackexchange.com/questions/256100/how-can-i-find-the-points-at-which-two-circles-intersect
     # https://gist.github.com/jupdike/bfe5eb23d1c395d8a0a1a4ddd94882ac
     # https://gist.github.com/jupdike/bfe5eb23d1c395d8a0a1a4ddd94882ac?permalink_comment_id=3590178#gistcomment-3590178
-    
+
     x1 = c1[0]
     y1 = c1[1]
     x2 = c2[0]
     y2 = c2[1]
 
     R = math.sqrt( (x1-x2)**2 + (y1-y2)**2 );
-    #if not ( abs(r1 - r2) <= R and R <= r1 + r2):  
+    #if not ( abs(r1 - r2) <= R and R <= r1 + r2):
     #    return [] # empty list of results
     #intersection(s) should exist
 
@@ -274,7 +274,7 @@ def circle_circle_intersect(c1,r1,c2,r2):
     gx = c * (y2 - y1) / 2;
 
     wx.LogError(f'gx: {gx}')
-    
+
     #note if gy == 0 and gx == 0 then the circles are tangent and there is only one solution
     #but that one solution will just be duplicated as the code is currently written
 
@@ -291,7 +291,7 @@ def circle_circle_intersect(c1,r1,c2,r2):
 
 
 def line_line_center(t1,t2, f):
-    """ Center of the arc fillet, given two straight tracks. The point is the intersection 
+    """ Center of the arc fillet, given two straight tracks. The point is the intersection
     of the track lines both offset by the fillet radius
 
     Args:
@@ -302,12 +302,12 @@ def line_line_center(t1,t2, f):
     Returns:
         _type_: _description_
     """
-    
+
     # solve unit vectors
     v1 = vec(t1)
     v2 = vec(t2)
-    v1u = v1/np.linalg.norm(v1) 
-    v2u = v2/np.linalg.norm(v2) 
+    v1u = v1/np.linalg.norm(v1)
+    v2u = v2/np.linalg.norm(v2)
     z = np.array([0,0,1])
 
     # side, cw or ccw
@@ -315,8 +315,8 @@ def line_line_center(t1,t2, f):
     c = np.cross(v1u,v2u)
     s = np.sign( np.dot(z,c) )
 
-    v1n = np.cross( z, v1u ) 
-    v2n = np.cross( z, v2u ) 
+    v1n = np.cross( z, v1u )
+    v2n = np.cross( z, v2u )
 
     # offset lines
     p1 = line_points(t1)
@@ -330,7 +330,7 @@ def line_line_center(t1,t2, f):
     return c
 
 def line_arc_center(t1, t2, f, side=1):
-    """ Center of the arc fillet, given one straight and one arc track. The point is the intersection 
+    """ Center of the arc fillet, given one straight and one arc track. The point is the intersection
     of the track lines offset by the fillet radius
 
     Args:
@@ -351,14 +351,14 @@ def line_arc_center(t1, t2, f, side=1):
         v2 = vec(t2)
 
         v1u = v1/np.linalg.norm(v1)
-        v2u = v2/np.linalg.norm(v2) 
+        v2u = v2/np.linalg.norm(v2)
         z = np.array([0,0,1])
-        
+
         # side, cw or ccw
         x = np.cross(v2u,v1u)   # !!!IMPORTANT!!!: order inverted wrt t2_arc
         s = np.sign( np.dot(z,x) )
 
-        v2n = np.cross( [0,0,s], v2u ) 
+        v2n = np.cross( [0,0,s], v2u )
 
         # offset circle
         o = t1.GetCenter()
@@ -377,15 +377,15 @@ def line_arc_center(t1, t2, f, side=1):
         v2 = tangent(t2)    # use the tg to the arc at its START point
 
         v1u = v1/np.linalg.norm(v1)
-        v2u = v2/np.linalg.norm(v2) 
+        v2u = v2/np.linalg.norm(v2)
         z = np.array([0,0,1])
 
         # side, cw or ccw
         x = np.cross(v1u,v2u)
         s = np.sign( np.dot(z,x) )
 
-        v1n = np.cross( [0,0,s], v1u ) 
-        
+        v1n = np.cross( [0,0,s], v1u )
+
         # offset line
         p1 = line_points(t1)
         p1 = p1 + np.dot( f, v1n )
@@ -410,12 +410,12 @@ def normalize(t):
     return n / t.GetLength()
 
 def tangent(t, end = False):
-    
+
     # find direction of tangent at start (or end) of arc track
     to = t.GetCenter()
     s = t.GetStart()
     e = t.GetEnd()
-    
+
     tp1 = e if end else s
     tp2 = s if end else e
 
@@ -426,7 +426,7 @@ def tangent(t, end = False):
     dy = tp2.y-tp1.y
     n = math.sqrt(dx**2+dy**2)
     pv = np.array([ dx/n, dy/n, 0])
-    
+
     x = np.cross(rv,pv)
     z = np.array([0,0,1])
     s = np.sign( np.dot(z,x) )
@@ -437,7 +437,7 @@ def tangent(t, end = False):
 def angle_and_bisect(t1, t2):
     # find angle and bisect vector between tracks, using tangent if track is arc
     # (assumes track1_end == track2_start)
-    
+
     if t1.GetClass() == 'PCB_ARC':
         v1 = tangent(t1, True)
     else:
@@ -445,7 +445,7 @@ def angle_and_bisect(t1, t2):
         t1e = t1.GetEnd()
         v1 = np.array([ t1e.x-t1s.x, t1e.y-t1s.y, 0 ])
         v1 = v1 / t1.GetLength()
-    
+
     if t2.GetClass() == 'PCB_ARC':
         v2 = tangent(t2)
     else:
@@ -454,16 +454,16 @@ def angle_and_bisect(t1, t2):
 
     z = np.array([0,0,1])
 
-    
+
     d = np.dot(v1,v2)
     c = np.cross(v1,v2)
     # +/- rotation?
     s = np.sign( np.dot(z,c) )
-    
-    # angle 
+
+    # angle
     a = s * math.acos(d)
-    
-    # normalized bisect 
+
+    # normalized bisect
     b = (v1+v2) / np.linalg.norm(v1+v2)
     b = np.cross(b,-z)
     b = b / np.linalg.norm(b)
@@ -491,6 +491,5 @@ def angle2(t1, t2):
     t1s = t1.GetStart()
     t1e = t1.GetEnd()
     t1v = pcbnew.VECTOR2I( t1e.x-t1s.x, t1e.y-t1s.y )
-    
+
     return t2v.Angle() - t1v.Angle()
-    

--- a/kimotor_stats.py
+++ b/kimotor_stats.py
@@ -9,9 +9,9 @@ def calc_length(board):
     tot = 0
     for track in board.GetTracks():
         l = track.GetLength()
-        tot += l/pcbnew.IU_PER_MM
+        tot += l/pcbnew.FromMM(1)
 
-    return tot 
+    return tot
 
 def calc_rlc(board, w, t, temp=20):
     """ Calculate resistance, inductance and capacitance of a track
@@ -31,9 +31,9 @@ def calc_rlc(board, w, t, temp=20):
     A = w*t
     r = rho * L/A
     rt = r * (1+alpha*(temp-20))
-    
+
 
     # https://resources.system-analysis.cadence.com/blog/msa2021-is-there-a-pcb-trace-inductance-rule-of-thumb
-    
+
 
     return rt


### PR DESCRIPTION
This patch makes the plugin work with kicad 7 (but breaks compatibility with v6)

You can use this as a basis to make it work with both kicad 7 and 6.

Btw due to other bugs I couldn't get valid results, only something like this (with default settings)

![image](https://user-images.githubusercontent.com/3622532/224544231-45b3507e-c75e-45d7-ab41-d844f0b4d3dd.png)

I get same results with current 0.1.1 release on v6 too so it's definitely something in plugin logic.